### PR TITLE
feat(opportunities): balance

### DIFF
--- a/src/components/element/reinvest/ReinvestBanner.tsx
+++ b/src/components/element/reinvest/ReinvestBanner.tsx
@@ -55,7 +55,7 @@ export default function ReinvestBanner() {
   if (!merklConfig.dashboard?.reinvestTokenAddress) return;
   return (
     <Group
-      className="rounded-md p-md bg-main-5 flex-nowrap items-start flex-col cursor-pointer !gap-0"
+      className="rounded-md p-md bg-main-8 flex-nowrap items-start flex-col cursor-pointer !gap-0"
       onClick={() => setIsOpen(!isOpen)}>
       <Group className="w-full justify-between">
         <Group>

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -91,6 +91,7 @@ const defaultMerklConfig: MerklConfig<Themes> = {
         },
       },
     },
+    minWalletBalance: 100,
   },
   bridge: {
     helperLink: "",

--- a/src/config/type.ts
+++ b/src/config/type.ts
@@ -49,6 +49,10 @@ export type MerklConfig<T extends Themes> = {
    */
   deposit?: boolean;
   /**
+   * Allows to override the token name displayed in the supply modal for idle tokens
+   */
+  clientTokenName?: string;
+  /**
    * Chains that can be connected to the dapp
    * @notice chains needs to be set in the wagmi config as well to allow wallets to connect
    */
@@ -142,6 +146,8 @@ export type MerklConfig<T extends Themes> = {
         };
       };
     };
+    // Minimum idle token balance to display the idle token modal for an opportunity
+    minWalletBalance: number;
   };
   opportunityLibrary: {
     defaultView?: OpportunityView;

--- a/src/modules/opportunity/components/library/OpportunityLibrary.tsx
+++ b/src/modules/opportunity/components/library/OpportunityLibrary.tsx
@@ -120,8 +120,8 @@ export default function OpportunityLibrary({
   return (
     <div className="flex flex-col w-full">
       {!hideFilters && (
-        <div className="overflow-x-visible -mx-lg md:-mx-xl lg:mx-0" ref={scrollContainerRef}>
-          <div className="min-w-min max-w-full px-lg md:px-xl lg:px-0">
+        <div className="overflow-x-visible -mx-[clamp(0.5rem,3vw,5rem)] lg:mx-0" ref={scrollContainerRef}>
+          <div className="min-w-min max-w-full px-[clamp(0.5rem,3vw,5rem)] lg:px-0">
             <Box content="sm" className="mb-lg justify-between w-full">
               <OpportunityFilters
                 {...{ only, chains, protocols, view, setView }}

--- a/src/modules/opportunity/components/library/OpportunityTable.tsx
+++ b/src/modules/opportunity/components/library/OpportunityTable.tsx
@@ -29,7 +29,7 @@ export const columns = {
   },
   action: {
     name: "Action",
-    size: "minmax(50px,150px)",
+    size: "minmax(min-content,150px)",
     className: "justify-end",
   },
   apr: {

--- a/src/modules/token/components/element/TokenSelect.tsx
+++ b/src/modules/token/components/element/TokenSelect.tsx
@@ -61,10 +61,12 @@ export default function TokenSelect({ tokens, balances, ...props }: TokenSelectP
                       <Text look="bold" bold>
                         {token.name}
                       </Text>
-                      <Text look="soft" className="flex gap-sm">
-                        {token.symbol} -{" "}
-                        <Value format={merklConfig.decimalFormat.dollar}>{Fmt.toPrice(token.balance, token)}</Value> -{" "}
-                        <Value format="0,0.###a">{Fmt.toNumber(token.balance, token.decimals)}</Value>{" "}
+                      <Text look="soft" className="flex">
+                        <Text look="soft" className="flex gap-sm">
+                          <Value format="0,0.###a">{Fmt.toNumber(token.balance, token.decimals)}</Value> {token.symbol}
+                        </Text>
+                        <span className="mr-sm" />(
+                        <Value format={merklConfig.decimalFormat.dollar}>{Fmt.toPrice(token.balance, token)}</Value>)
                       </Text>
                     </Group>
                   </Group>

--- a/src/modules/user/routes/user.$address.rewards.tsx
+++ b/src/modules/user/routes/user.$address.rewards.tsx
@@ -35,12 +35,6 @@ export default function Index() {
   return (
     <Container>
       <Space size="md" />
-      {!!I18n.trad.get.pages.dashboard.reinvest && tokenBalance > 0 && (
-        <>
-          <ReinvestBanner />
-          <Space size="md" />
-        </>
-      )}
       {!!I18n.trad.get.pages.dashboard.explanation && (
         <>
           <Group className="rounded-md p-md bg-main-5 flex-nowrap items-start">
@@ -49,6 +43,12 @@ export default function Index() {
               {I18n.trad.get.pages.dashboard.explanation}
             </Text>
           </Group>
+          <Space size="md" />
+        </>
+      )}
+      {!!I18n.trad.get.pages.dashboard.reinvest && tokenBalance > 100 && (
+        <>
+          <ReinvestBanner />
           <Space size="md" />
         </>
       )}

--- a/src/modules/user/routes/user.$address.rewards.tsx
+++ b/src/modules/user/routes/user.$address.rewards.tsx
@@ -46,7 +46,7 @@ export default function Index() {
           <Space size="md" />
         </>
       )}
-      {!!I18n.trad.get.pages.dashboard.reinvest && tokenBalance > 100 && (
+      {!!I18n.trad.get.pages.dashboard.reinvest && tokenBalance > merklConfig.opportunity?.minWalletBalance && (
         <>
           <ReinvestBanner />
           <Space size="md" />


### PR DESCRIPTION
- remove negative margins on table
- Change background color on the idle ZK
- Only show the modal on ZK opportunities if you have >100 ZK in your wallet
- Keep the modal: “Pending rewards are updated approximately every ~4 hours, and become claimable onchain every Monday” at the top
- Adjust balance display on Simple Supply modal